### PR TITLE
Update the branch of laravel-mix-boilerplate-wordpress to master

### DIFF
--- a/script/wordpress.js
+++ b/script/wordpress.js
@@ -37,7 +37,7 @@ inquirer.prompt([{
             download('https://github.com/liginc/lig-docker-wordpress.git', 'master', false, false, false, true);
         })
         .then(function () {
-            download('https://github.com/liginc/laravel-mix-boilerplate-wordpress.git', 'feature/optimize-directory-for-docker', false, true, true, true);
+            download('https://github.com/liginc/laravel-mix-boilerplate-wordpress.git', 'master', false, true, true, true);
         })
         .then(function () {
             download('https://github.com/liginc/lig-wordpress-template.git', 'master', 'wp/wp-content/themes/lig', false);


### PR DESCRIPTION
laravel-mix-boilerplate-wordpressを、masterブランチから取得するように変更しました。

larami-wpのPRがmasterへマージ（20191108予定）された後に、マージ実行をお願いします。
https://github.com/liginc/laravel-mix-boilerplate-wordpress/pull/1

（20191108追記）larami-wpのマージ完了したので、このPR、マージ可能な状態です！